### PR TITLE
add AI Opt-Out policy to org root

### DIFF
--- a/tf/organizations.tf
+++ b/tf/organizations.tf
@@ -1,3 +1,25 @@
 resource "aws_organizations_organization" "org" {
   feature_set = "ALL"
 }
+
+resource "aws_organizations_policy" "ai_opt_out" {
+  name = "AIServicesOptOutAll"
+  content = jsonencode({
+    services = {
+      "@@operators_allowed_for_child_policies" = ["@@none"],
+      default = {
+        "@@operators_allowed_for_child_policies" = ["@@none"],
+        opt_out_policy = {
+          "@@operators_allowed_for_child_policies" = ["@@none"],
+          "@@assign"                               = "optOut"
+        }
+      }
+    }
+  })
+}
+
+resource "aws_organizations_policy_attachment" "ai_opt_out_root" {
+  for_each  = toset(aws_organizations_organization.org.roots.*.id)
+  policy_id = aws_organizations_policy.ai_opt_out.id
+  target_id = each.value
+}


### PR DESCRIPTION
It [turns out](https://www.cbronline.com/news/aws-user-data) that AWS AI services chose to use an opt-out instead of an opt-in policy for retaining customers' data. Let's go ahead and put an SCP in place for AWS Organizations that flips the opt-out bit.

From [the docs](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_ai-opt-out.html):
> Certain AWS artificial intelligence (AI) services ... may store and use customer content processed by those services for the development and continuous improvement of Amazon AI services and technologies. As an AWS customer, you can choose to opt out of having your content stored or used for service improvements. Instead of configuring this setting individually for each AWS account that your organization uses, you can configure an organization policy that enforces your setting choice on all accounts that are members of the organization. You can choose to opt out of content storage and use for an individual AI service, or for all of the covered services at once.

> The following [example](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_ai-opt-out_syntax.html#ai-opt-out-policy-example-1) shows a policy that you could attach to your organization's root to opt out of AI services for accounts in your organization.

```json
{
    "services": {
        "@@operators_allowed_for_child_policies": ["@@none"],
        "default": {
            "@@operators_allowed_for_child_policies": ["@@none"],
            "opt_out_policy": {
                "@@operators_allowed_for_child_policies": ["@@none"],
                "@@assign": "optOut"
            }
        }
    }
}
```

More info: [AI services opt-out policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_ai-opt-out.html)