### PR TITLE
Update terraform.yaml

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -21,7 +21,7 @@ jobs:
         working-directory: ./tf
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: 'Configure AWS Credentials'
         id: aws


### PR DESCRIPTION
`actions/checkout` is now using `main` instead of `master` as the trunk branch.