### PR TITLE
ignore enabled_policy_types until provider supports updated list

### DIFF
--- a/tf/organizations.tf
+++ b/tf/organizations.tf
@@ -1,5 +1,9 @@
 resource "aws_organizations_organization" "org" {
   feature_set = "ALL"
+
+  lifecycle {
+    ignore_changes = [enabled_policy_types]
+  }
 }
 
 resource "aws_organizations_policy" "ai_opt_out" {


### PR DESCRIPTION
#3 failed because of some issues upstream.

https://github.com/terraform-providers/terraform-provider-aws/issues/14142 is to support the new `AISERVICES_OPT_OUT_POLICY` type for Organizations Policies. It is blocked by https://github.com/terraform-providers/terraform-provider-aws/pull/14000, which will update the provider to use a more recent version of the AWS SDK for Go, which adds that new type.

until those upstream issues are fixed, we manually enabled the type and we'll just need to ignore lifecycle changes until the terraform provider will accept the new policy type.