### PR TITLE
Revert AWS Organizations Policies

### DIFF
--- a/tf/organizations.tf
+++ b/tf/organizations.tf
@@ -1,25 +1,3 @@
 resource "aws_organizations_organization" "org" {
   feature_set = "ALL"
 }
-
-resource "aws_organizations_policy" "ai_opt_out" {
-  name = "AIServicesOptOutAll"
-  content = jsonencode({
-    services = {
-      "@@operators_allowed_for_child_policies" = ["@@none"],
-      default = {
-        "@@operators_allowed_for_child_policies" = ["@@none"],
-        opt_out_policy = {
-          "@@operators_allowed_for_child_policies" = ["@@none"],
-          "@@assign"                               = "optOut"
-        }
-      }
-    }
-  })
-}
-
-resource "aws_organizations_policy_attachment" "ai_opt_out_root" {
-  for_each  = toset(aws_organizations_organization.org.roots.*.id)
-  policy_id = aws_organizations_policy.ai_opt_out.id
-  target_id = each.value
-}


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-aws/issues/14142 is to support the new `AISERVICES_OPT_OUT_POLICY` type for Organizations Policies. It is blocked by https://github.com/terraform-providers/terraform-provider-aws/pull/14000, which will update the provider to use a more recent version of the AWS SDK for Go, which adds that new type.

until those upstream issues are fixed, we'll hold off on managing those policies in Terraform.